### PR TITLE
return actual port used from start

### DIFF
--- a/lib/src/mockserver/mock_server.dart
+++ b/lib/src/mockserver/mock_server.dart
@@ -13,9 +13,10 @@ class MockServer {
     this.endPointDelay = 0,
   });
 
-  Future<dynamic> start() async {
+  Future<int> start() async {
     _server = await HttpServer.bind(InternetAddress.anyIPv6, port);
     _server.listen(_onRequest);
+    return _server.port;
   }
 
   Future<dynamic> stop() => _server.close();


### PR DESCRIPTION
This PR makes `start` return the actual port used by the `_server`. In the case you provide zero as a port, the system chooses the port. This allows you to get and do something with the returned port.

```
  /// If [port] has the value 0 an ephemeral port will be chosen by
  /// the system. The actual port used can be retrieved using the
  /// [port] getter.
```